### PR TITLE
Update README, fix LinkedIn profile link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Author
 
-Shawn D'Souza
+iOS DeCal Course Staff
 
 ## Purpose
 

--- a/index.html
+++ b/index.html
@@ -327,7 +327,7 @@
         <div class="former-grid-semester">fall 2015, spring 2016</div>
       </div>
       <div class="former-grid "> <img src="past-staff-photos/shawn.jpg" alt="Shawn D'Souza">
-        <div class="former-grid-name"><a href="https://www.linkedin.com/in/shawn-d-souza-a8802b66">Shawn D'Souza</a></div>
+        <div class="former-grid-name"><a href="https://www.linkedin.com/in/shawnpdsouza">Shawn D'Souza</a></div>
         <div class="former-grid-semester">fall 2015, spring 2016</div>
       </div>
     </div>


### PR DESCRIPTION
- README should reflect the contributions of all iOS DeCal staff
who have made lovely contributions to the website's design (e.g.
Paige, Marisa, etc.)
- Fixed Shawn's LinkedIn profile link to use the custom public URL

I'm not so vain where I still need my name on the authorship of this website. I started it with hacked together basic HTML/CSS (I hate web development), but successive members of the course staff have greatly improved it.

TLDR: Nerf Shawn